### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/elmo-chainer/README.md
+++ b/elmo-chainer/README.md
@@ -79,7 +79,7 @@ with h5py.File(embedding_file, 'r') as fin:
 - Can load model files with the orignal formats.
 - Training of weight-sum layers is supported.
 - Pretraining of biLM is NOT supported.
-- Finetuning of biLM in downstream tasks is possible but disable by default.
+- Finetuning of biLM in downstream tasks is possible but disabled by default.
 - Excuse: This is modified to work on both py3 and py2 unlike original implementations, but py3 is recommended.
 - Docstrings in code are still old, i.e. written for pytorch, but you can almost read them due to similarity with chainer.
 
@@ -103,7 +103,7 @@ pip install cupy
 ### Appendix
 
 Elmo takes as input tokenized sentences.
-It does not requires lowercasing but requires separating punctuations without words.
+It does not require lowercasing but requires separating punctuations without words.
 A lazy user can perform the punctuation-separation with a simple script as follows:
 
 ```


### PR DESCRIPTION
Fix minor typo in `README.md`